### PR TITLE
Update to 0.7, replace Requests with HTTP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: julia
 julia:
     - nightly
-#script:
-#    - julia -e 'Pkg.clone(pwd()); Pkg.build("Zabbix"); Pkg.test("Zabbix"; coverage=true)';
-#after_success:
-#    - julia -e 'cd(Pkg.dir("Zabbix")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())';
+script:
+    - julia -e 'Pkg.clone(pwd()); Pkg.build("Zabbix"); Pkg.test("Zabbix"; coverage=true)';
+after_success:
+    - julia -e 'cd(Pkg.dir("Zabbix")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())';

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: julia
 julia:
-    - 0.6
-script:
-    - julia -e 'Pkg.clone(pwd()); Pkg.build("Zabbix"); Pkg.test("Zabbix"; coverage=true)';
-after_success:
-    - julia -e 'cd(Pkg.dir("Zabbix")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())';
+    - nightly
+#script:
+#    - julia -e 'Pkg.clone(pwd()); Pkg.build("Zabbix"); Pkg.test("Zabbix"; coverage=true)';
+#after_success:
+#    - julia -e 'cd(Pkg.dir("Zabbix")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())';

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: julia
 julia:
     - nightly
 script:
-    - julia -e 'Pkg.clone(pwd()); Pkg.build("Zabbix"); Pkg.test("Zabbix"; coverage=true)';
+    - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("Zabbix"); Pkg.test("Zabbix"; coverage=true)';
 after_success:
-    - julia -e 'cd(Pkg.dir("Zabbix")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())';
+    - julia -e 'using Pkg; cd(Pkg.dir("Zabbix")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())';

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
-Requests
+HTTP
 JSON

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.6
+julia 0.7
 HTTP
 JSON

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Zabbix
-using Base.Test
+using Test
 
 z = Zabbix.ZabbixAPI("https://www.example.com/zabbix/api_jsonrpc.php","username","password") 
 @test typeof(z) == ZabbixAPI


### PR DESCRIPTION
I have tested this against a Zabbix server running 3.2.11, and as far as I can tell, everything works as intended. I believe this is ready for 1.0, but I didn't want to hastily make that jump in REQUIRE, just to be safe.